### PR TITLE
Stripe CLIで定期支払いのWebhookをエミュレートする

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,8 @@ STRIPE_KEY_SECRET=シークレットキー
 # プランを作成する https://dashboard.stripe.com/test/subscriptions
 STRIPE_PLAN_ID=plan_xxxxxxxxxxxxxx
 
+# 次のいずれかで用意する
+# - [ダッシュボードでエンドポイントを作成する](https://dashboard.stripe.com/test/webhooks)
+# - [`$ stripe listen --forward-to localhost:3000/hooks/stripe`](https://stripe.com/docs/stripe-cli)
+STRIPE_WEBHOOK_SECRET=whsec_xxxxxxxxxxxx
+

--- a/README.md
+++ b/README.md
@@ -32,6 +32,37 @@ $ gem install foreman
 $ foreman start
 ```
 
+## アプリケーションを試す
+
+### ブラウザで操作する
+
+http://localhost:3000/ にアクセスし、UIが示す操作を行う。
+
+
+### 定期支払いのWebhookをエミュレートする
+
+Stripe公式のコマンドラインツールをインストールする。
+
+- [Using the Stripe CLI | Stripe](https://stripe.com/docs/stripe-cli)
+
+`stripe trigger` でイベントを送信するため、事前に `stripe listen` を実行する。
+
+```sh
+$ stripe listen --forward-to localhost:3000/hooks/stripe
+```
+
+出力されるキー（ `whsec_xxxxxxxx` ）を環境変数 `STRIPE_WEBHOOK_SECRET` にセットする。
+
+その後、 `stripe trigger` でイベントをローカルのサーバーに送信する。
+
+```sh
+### 定期支払いに成功したときのイベントを送信する
+$ stripe trigger invoice.payment_succeeded
+
+### 定期支払いに失敗したときのイベント
+$ stripe trigger invoice.payment_succeeded
+```
+
 ## 構成について
 
 `session` で保持する値は本来テーブル（データベース）に保存するべき値。
@@ -40,3 +71,20 @@ $ foreman start
 $ git grep session
 ```
 
+## トラブルシューティング
+
+### `stripe trigger` でイベントが飛ばない
+
+いくつかの可能性がある。
+
+- `stripe listen --forward-to $WEBHOOK_URL` を起動していない
+- 数分遅れてイベントが飛ぶ場合がある
+
+## リソース
+
+- [ダッシュボード - Stripe](https://dashboard.stripe.com/)
+- [Documentation | Stripe](https://stripe.com/docs)
+- [Checkout overview | Stripe Checkout](https://stripe.com/docs/payments/checkout)
+- [Subscription lifecycle and events | Stripe Billing](https://stripe.com/docs/billing/subscriptions/overview#settings)
+- [Using the Stripe CLI | Stripe](https://stripe.com/docs/stripe-cli)
+- [Stripe定期課金のライフサイクル - Innovator Japan Engineers’ Blog](https://tech.innovator.jp.net/entry/stripe-subscription-billing-lifecycle-event)

--- a/app/controllers/api/subscriptions_controller.rb
+++ b/app/controllers/api/subscriptions_controller.rb
@@ -3,7 +3,6 @@
 require 'stripe'
 
 class Api::SubscriptionsController < ApplicationController
-
   def subscribe
     base_url = "#{request.scheme}://#{request.host}:#{request.port}"
     # `session` は 既に ApplicationController が定義しているため、
@@ -45,7 +44,7 @@ class Api::SubscriptionsController < ApplicationController
       subscription = Stripe::Subscription.delete(stripe_user.subscription_id)
       if subscription.canceled_at > 0
         stripe_user.update(
-          subscription_id: nil
+          is_subscribed: false
         )
         render json: nil, status: :ok
       else
@@ -79,6 +78,11 @@ class Api::SubscriptionsController < ApplicationController
       email: session['user_email'],
       invoice_settings: {
         default_payment_method: create_params[:payment_method_id]
+      },
+      # アプリケーション独自のデータをmetadataで保持できる
+      # 検索例: https://dashboard.stripe.com/test/search?query=metadata%3Auser_id%3D1
+      metadata: {
+        user_id: session[:user_id]
       }
     )
     session[:customer_id] = response.id

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
-  protect_from_forgery with: :exception
+  protect_from_forgery with: :exception, if: :protected_with_csrf_token
+
+  protected
+
+  def protected_with_csrf_token
+    true
+  end
 end

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -15,6 +15,7 @@ class AuthController < ApplicationController
     if stripe_user.present?
       stripe_user.update(
         customer_id: nil,
+        is_subscribed: false,
         session_id: nil,
         subscription_id: nil
       )

--- a/app/controllers/hooks/stripe_controller.rb
+++ b/app/controllers/hooks/stripe_controller.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'stripe'
+
+class Hooks::StripeController < ApplicationController
+  def protected_with_csrf_token
+    false
+  end
+
+  # ここに飛んでくるイベントは30日間アクセス可能。
+  # サポート対応やデバッグのためにIDの保持を検討するのも手か。
+  # >NOTE: Right now, access to events through the Retrieve Event API is guaranteed only for 30 days.
+  # https://stripe.com/docs/api/events
+  def create
+    # リクエストを検証する
+    # https://stripe.com/docs/webhooks/signatures
+    payload = request.body.read
+    sig_header = request.env['HTTP_STRIPE_SIGNATURE']
+    event = nil
+    begin
+      event = Stripe::Webhook.construct_event(
+        payload, sig_header, ENV['STRIPE_WEBHOOK_SECRET']
+      )
+    rescue JSON::ParserError => e
+      # Invalid payload
+      logger.error(e)
+    rescue Stripe::SignatureVerificationError => e
+      # Invalid signature
+      logger.error(e)
+    end
+    return render json: nil, status: :bad_request if event.blank?
+
+    # `event` の型は `event.type` の前半（ドット以前）と同名のもの。
+    # 例） `invoice.payment_succeeded` の場合、`event` の型は `Stripe::Invoice`
+    logger.debug "event: #{event.class.name}"
+
+    # Handle the event
+    case event.type
+    when 'invoice.payment_succeeded'
+      invoice_payment_succeeded(event)
+      render json: nil, status: :ok
+    when 'invoice.payment_failed'
+      invoice_payment_failed(event)
+      render json: nil, status: :ok
+    else
+      # Unexpected event type
+      render json: nil, status: :bad_request
+    end
+  end
+
+  protected
+
+  # いまの要件は *ユーザーが1人* なのでcustomer（StripeUser.customer_id）はチェックしない。
+  # 理由はCLIツールの制約によるもの。回避策として `StripeUser.first` で代用する。
+  #
+  # 1. `$ stripe trigger` ではパラメーター（例：customer）を固定することができない
+  # 2. `$ stripe fixtures` でパラメーターを固定できるが、データ構造が違うため、Webhook の代替にならない
+  #
+  # ダッシュボードでWebhookを登録してイベントを受け取る場合、`StripeUser.first` による回避策が不要になる。
+
+  def invoice_payment_succeeded(_event)
+    stripe_user = StripeUser.first
+    stripe_user.is_subscribed = true
+    stripe_user.save
+  end
+
+  # ここに到達した時点で定期課金の失敗は確定している
+  # >When an automatic payment on a subscription fails, a charge.failed event and an invoice.payment_failed event are sent
+  #
+  # より複雑な状態管理を実装する場合はSubscriptionオブジェクトのstatusを利用する選択肢がある。
+  # >and the subscription state becomes past_due. Stripe attempts to recover payment according to your configured retry rules.
+  # https://stripe.com/docs/billing/subscriptions/overview#inactive
+  #
+  # Subscriptionオブジェクト
+  # https://stripe.com/docs/api/subscriptions/object
+  def invoice_payment_failed(_event) # Stripe::Invoice
+    stripe_user = StripeUser.first
+    stripe_user.is_subscribed = false
+    stripe_user.save
+    pp stripe_user
+  end
+end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -6,7 +6,7 @@
 # https://stripe.com/docs/payments/checkout/subscriptions/starting
 class SubscriptionsController < ApplicationController
   def index
-    @subscribed = StripeUser.find_by(user_id: session['user_id']).subscribed?
+    @stripe_user = StripeUser.find_by(user_id: session[:user_id])
   end
 
   def success
@@ -25,6 +25,7 @@ class SubscriptionsController < ApplicationController
       # https://stripe.com/docs/api/checkout/sessions/retrieve
       checkout_session = Stripe::Checkout::Session.retrieve(success_params[:session_id])
       stripe_user.update(
+        is_subscribed: true,
         # subscription_id: "sub_xxxxxxx..."
         subscription_id: checkout_session.subscription
       )

--- a/app/models/stripe_user.rb
+++ b/app/models/stripe_user.rb
@@ -4,6 +4,6 @@
 # https://stripe.com/docs/payments/checkout
 class StripeUser < ApplicationRecord
   def subscribed?
-    subscription_id.present?
+    is_subscribed
   end
 end

--- a/app/views/subscriptions/index.html.erb
+++ b/app/views/subscriptions/index.html.erb
@@ -7,7 +7,12 @@
   # app/javascript/packs/subscriptions.js
 %>
 
-<% if @subscribed %>
+<ul>
+  <li>is_subscribed: <%= @stripe_user.subscribed? %></li>
+  <li>customer_id: <%= @stripe_user.customer_id %></li>
+</ul>
+
+<% if @stripe_user.subscribed? %>
   <%= button_tag '購読を解除する', id: "unsubscribe" %>
 <% else %>
   <p>テスト用カード番号: <a href="https://stripe.com/docs/billing/subscriptions/cards#test-integration" target="_blank">Subscriptions with card payments | Stripe Billing</a></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,11 @@ Rails.application.routes.draw do
     end
   end
 
+  # webhooks
+  namespace :hooks do
+    resources :stripe, only: %w[create]
+  end
+
   # JavaScriptから叩くAPI
   namespace :api do
     post '/subscriptions', action: :subscribe, controller: :subscriptions

--- a/db/migrate/20200501101725_add_is_subscribed_to_stripe_users.rb
+++ b/db/migrate/20200501101725_add_is_subscribed_to_stripe_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIsSubscribedToStripeUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :stripe_users, :is_subscribed, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,15 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_28_051143) do
+ActiveRecord::Schema.define(version: 2020_05_01_101725) do
 
-  create_table "stripe_users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "stripe_users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "customer_id"
     t.string "session_id"
     t.string "subscription_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "is_subscribed", default: true, null: false
   end
 
 end


### PR DESCRIPTION
#3 

File changed を見やすくするため、マージ先のブランチは #6 にしています。

ここに書こうと思った共有事項は [README](https://github.com/gaiax/rails-subscription-sample/pull/9/files#diff-04c6e90faac2675aa89e2176d2eec7d8)にまとめました。（Stripe CLIも同様に）

それに加えて、動作させるには `rails db:migrate` も必要です。